### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/central_server_tests.yml
+++ b/.github/workflows/central_server_tests.yml
@@ -1,5 +1,8 @@
 name: Test central server
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/MoritzBernhofer/interface/security/code-scanning/1](https://github.com/MoritzBernhofer/interface/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs basic CI tasks (restoring dependencies, building, and testing), it requires minimal permissions. The `contents: read` permission is sufficient for these operations. This change will ensure the workflow does not inherit overly permissive default permissions.

The `permissions` block should be added at the root level of the workflow file, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
